### PR TITLE
fixes map level join error

### DIFF
--- a/global.R
+++ b/global.R
@@ -20,7 +20,7 @@ ca_cities <- readRDS( file = "shapes/ca_cities.rds")
 usa1 <- readRDS("shapes/usa1.RDS")
 usa2 <- readRDS("shapes/usa2.RDS") #(counties)shapes/usa2.RDS
 ### does not work
-spdfs_list <- list(usa1, usa2, ca_cities, ca_cities)
+spdfs_list <- list(usa1, usa2, ca_cities)
 #for joining need to tell it NAME_2 = COUNTY
 
 

--- a/server.R
+++ b/server.R
@@ -1,6 +1,6 @@
 
 server <- function(input, output) {
-  my_leafdown <- Leafdown$new(spdfs_list, "leafdown", input, join_map_levels_by = c("GID_0" = "GID_0", "GID_1" = "GID_1", "NAME_2" = "COUNTY")
+  my_leafdown <- Leafdown$new(spdfs_list, "leafdown", input, join_map_levels_by = c("GID_0" = "GID_0", "NAME_2" = "COUNTY")
   )
   active_marker_ids <- NULL
   markers <- NULL


### PR DESCRIPTION
For three map levels, we need three elements in the `spdf_list` and two elements in the `join_map_levels_by` vector (the first element joins the first and second map levels and the second element joins the second and third).

What is left to do is to adjust the data aggregation function for the third map layer (at the moment there is an error once you drill down to the third map level, but you can aggregate the data in the same way as you did for the first and second map layers) :